### PR TITLE
Add NOP_EXIT_SILENT support

### DIFF
--- a/cpu/or1k/spr-defs.h
+++ b/cpu/or1k/spr-defs.h
@@ -636,5 +636,6 @@
 #define NOP_TRACE_OFF    0x0009      /* Turn off tracing */
 #define NOP_RANDOM       0x000a      /* Return 4 random bytes */
 #define NOP_OR1KSIM      0x000b      /* Return non-zero if this is Or1ksim */
+#define NOP_EXIT_SILENT  0x000c      /* End of simulation, quiet version */
 
 #endif	/* SPR_DEFS__H */

--- a/cpu/or32/insnset.c
+++ b/cpu/or32/insnset.c
@@ -559,6 +559,7 @@ INSTRUCTION (l_nop) {
       PRINTFQ(" diff  : cycles %lld, insn #%lld\n",
               runtime.sim.cycles - runtime.sim.reset_cycles,
               runtime.cpu.instructions - runtime.cpu.reset_instructions);
+    case NOP_EXIT_SILENT:
       if (config.sim.is_library)
 	{
 	  runtime.cpu.halted = 1;

--- a/testsuite/test-code-or1k/support/spr-defs.h
+++ b/testsuite/test-code-or1k/support/spr-defs.h
@@ -636,5 +636,6 @@
 #define NOP_TRACE_OFF    0x0009      /* Turn off tracing */
 #define NOP_RANDOM       0x000a      /* Return 4 random bytes */
 #define NOP_OR1KSIM      0x000b      /* Return non-zero if this is Or1ksim */
+#define NOP_EXIT_SILENT  0x000c      /* End of simulation, quiet version */
 
 #endif	/* SPR_DEFS__H */


### PR DESCRIPTION
This patch adds support for NOP_EXIT_SILENT (0x000c)
opcode. This opcode acts like NOP_EXIT but doesn't print
anything while exiting.

NOP_EXIT_SILENT was introduce in the new or1k toolchain.

See:
http://www.mail-archive.com/openrisc@lists.openrisc.net/msg00637.html

Signed-off-by: Franck Jullien franck.jullien@gmail.com
