### PR TITLE
rsp: Return proper error condition on unrecognized 'v' command

### DIFF
--- a/debug/rsp-server.c
+++ b/debug/rsp-server.c
@@ -2152,7 +2152,7 @@ rsp_vpkt (struct rsp_buf *buf)
     {
       fprintf (stderr, "Warning: Unknown RSP 'v' packet type %s: ignored\n",
 	       buf->data);
-      put_str_packet ("E01");
+      put_str_packet ("");
       return;
     }
 }	/* rsp_vpkt () */


### PR DESCRIPTION
An upstream commit 57809e5e5 in gdb causes gdb remote client to abort if
the server returns a non blank response when handling an unknown
request.

gdb remote connect fails with:
  Remote replied unexpectedly to 'vMustReplyEmpty': E01

This change is to return "" is as per spec so gdb connections do not abort.
- ChangeLog:

20156-09-18  Stafford Horne shorne@gmail.com

```
* debug/rsp-server.c: return "" on unknown vpacket
```
