### PR TITLE
Fix build with musl libc

### DIFF
--- a/peripheral/eth.c
+++ b/peripheral/eth.c
@@ -41,14 +41,9 @@
 #include <sys/types.h>
 #include <fcntl.h>
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <unistd.h>
 #include <errno.h>
-
-#if HAVE_LINUX_IF_TUN_H==1
-#include <linux/if.h>
-#include <linux/if_tun.h>
-#endif
 
 /* Package includes */
 #include "arch.h"
@@ -65,6 +60,10 @@
 #include "toplevel-support.h"
 #include "sim-cmd.h"
 
+#if HAVE_LINUX_IF_TUN_H==1
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#endif
 
 /* Control debug messages */
 #define ETH_DEBUG 0

--- a/vapi/vapi.c
+++ b/vapi/vapi.c
@@ -33,7 +33,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <fcntl.h>


### PR DESCRIPTION
Use poll.h instead of sys/poll.h, or else musl warns.

Include Linux headers last, after all libc headers, so the libc headers
can suppress duplicate definitions from the Linux headers.

Signed-off-by: Samuel Holland <samuel@sholland.org>