### PR TITLE
Fix the build on big-endian hosts and a related cleanup

### DIFF
--- a/cpu/common/elf.h
+++ b/cpu/common/elf.h
@@ -6,8 +6,8 @@
 #endif
 
 #ifdef WORDS_BIGENDIAN
-#define ELF_SHORT_H
-#define ELF_LONG_H
+#define ELF_SHORT_H(ps) ((unsigned short)(ps))
+#define ELF_LONG_H(ps)  ((unsigned long)(ps))
 #else
 /* Load a short int from the following tables with big-endian formats */
 #define ELF_SHORT_H(ps) ((((unsigned short)(ps) >> 8) & 0xff) |\

--- a/debug/rsp-server.c
+++ b/debug/rsp-server.c
@@ -1190,8 +1190,8 @@ reg2hex (unsigned long int  val,
 
   for (n = 0; n < 8; n++)
     {
-#ifdef WORDSBIGENDIAN
-      int  nyb_shift = n * 4;
+#ifdef WORDS_BIGENDIAN
+      int  nyb_shift = (n ^ 1) * 4;
 #else
       int  nyb_shift = 28 - (n * 4);
 #endif
@@ -1221,8 +1221,8 @@ hex2reg (char *buf)
 
   for (n = 0; n < 8; n++)
     {
-#ifdef WORDSBIGENDIAN
-      int  nyb_shift = n * 4;
+#ifdef WORDS_BIGENDIAN
+      int  nyb_shift = (n ^ 1) * 4;
 #else
       int  nyb_shift = 28 - (n * 4);
 #endif

--- a/peripheral/memory.c
+++ b/peripheral/memory.c
@@ -90,7 +90,7 @@ simmem_read8 (oraddr_t addr, void *dat)
 #ifdef WORDS_BIGENDIAN
   return *(uint8_t *) (dat + addr);
 #else
-  return *(uint8_t *) (dat + ((addr & ~ADDR_C (3)) | (3 - (addr & 3))));
+  return *(uint8_t *) (dat + (addr ^ 3));
 #endif
 }
 
@@ -116,7 +116,7 @@ simmem_write8 (oraddr_t addr, uint8_t value, void *dat)
 #ifdef WORDS_BIGENDIAN
   *(uint8_t *) (dat + addr) = value;
 #else
-  *(uint8_t *) (dat + ((addr & ~ADDR_C (3)) | (3 - (addr & 3)))) = value;
+  *(uint8_t *) (dat + (addr ^ 3)) = value;
 #endif
 }
 

--- a/peripheral/vga.c
+++ b/peripheral/vga.c
@@ -177,11 +177,12 @@ vga_read32 (oraddr_t addr, void *dat)
 
 /* This code will only work on little endian machines */
 #ifdef __BIG_ENDIAN__
-#warning Image dump not supported on big endian machines
 
 static int
-vga_dump_image (char *filename, struct vga_start *vga)
+vga_dump_image (char *filename, struct vga_state *vga)
 {
+  fprintf (stderr, "Image dump not supported on big endian machines\n");
+
   return 1;
 }
 


### PR DESCRIPTION
This allows me to compile and run or1ksim on a powerpc64 box.