### PR TITLE
rsp-server: Handle vMustReplyEmpty packets

### DIFF
--- a/debug/rsp-server.c
+++ b/debug/rsp-server.c
@@ -2150,8 +2150,12 @@ rsp_vpkt (struct rsp_buf *buf)
     }
   else
     {
-      fprintf (stderr, "Warning: Unknown RSP 'v' packet type %s: ignored\n",
-	       buf->data);
+      /* GDB expects an empty response for unknown 'v' packets. */
+      if (0 != strcmp ("vMustReplyEmpty", buf->data))
+	{
+	  fprintf (stderr, "Warning: Unknown RSP 'v' packet type %s: ignored\n",
+		   buf->data);
+	}
       put_str_packet ("");
       return;
     }


### PR DESCRIPTION
GDB sends vMustReplyEmpty as a feature test to detect [old/broken GDB
server behavior][1]. The correct reply is an empty response, which is
what we already send, but we warn about it. Since we should expect to
receive this packet, silence the warning, and add a comment to ensure
we maintain the expected behavior.

[1]: https://sourceware.org/gdb/onlinedocs/gdb/Packets.html

Signed-off-by: Samuel Holland <samuel@sholland.org>