### PR TITLE
[RFC] Abstract the target endianness with a macro

### DIFF
--- a/cpu/common/abstract.h
+++ b/cpu/common/abstract.h
@@ -64,7 +64,12 @@
 #endif /* ULONGEST */
 
 /* Endianness convenience macros */
+#define TARGET_BIG_ENDIAN
+#ifdef TARGET_BIG_ENDIAN
 #define LE16(x) bswap_16(x)
+#else
+#define LE16(x) ((uint16_t)(x))
+#endif
 
 /*! Instruction queue */
 struct iqueue_entry

--- a/cpu/common/elf.h
+++ b/cpu/common/elf.h
@@ -5,7 +5,7 @@
 #include <config.h>
 #endif
 
-#ifdef WORDS_BIGENDIAN
+#if defined(TARGET_BIG_ENDIAN) == defined(WORDS_BIGENDIAN)
 #define ELF_SHORT_H(ps) ((unsigned short)(ps))
 #define ELF_LONG_H(ps)  ((unsigned long)(ps))
 #else

--- a/cpu/common/parse.c
+++ b/cpu/common/parse.c
@@ -273,7 +273,7 @@ check_insn (uint32_t insn)
 /*---------------------------------------------------------------------------*/
 /*!Add an instruction to the program
 
-  @note insn must be in big endian format
+  @note insn must be in target endian format
 
   @param[in] address     The address to use
   @param[in] insn        The instruction to add
@@ -290,10 +290,17 @@ addprogram (oraddr_t  address,
 
   /* We can't have set_program32 functions since it is not gauranteed that the
      section we're loading is aligned on a 4-byte boundry */
-  set_program8 (vaddr, (insn >> 24) & 0xff);
+#ifdef TARGET_BIG_ENDIAN
+  set_program8 (vaddr + 0, (insn >> 24) & 0xff);
   set_program8 (vaddr + 1, (insn >> 16) & 0xff);
-  set_program8 (vaddr + 2, (insn >> 8) & 0xff);
-  set_program8 (vaddr + 3, insn & 0xff);
+  set_program8 (vaddr + 2, (insn >>  8) & 0xff);
+  set_program8 (vaddr + 3, (insn >>  0) & 0xff);
+#else
+  set_program8 (vaddr + 3, (insn >> 24) & 0xff);
+  set_program8 (vaddr + 2, (insn >> 16) & 0xff);
+  set_program8 (vaddr + 1, (insn >>  8) & 0xff);
+  set_program8 (vaddr + 0, (insn >>  0) & 0xff);
+#endif
 
 #if IMM_STATS
   check_insn (insn);

--- a/peripheral/memory.c
+++ b/peripheral/memory.c
@@ -77,7 +77,7 @@ simmem_read32 (oraddr_t addr, void *dat)
 static uint16_t
 simmem_read16 (oraddr_t addr, void *dat)
 {
-#ifdef WORDS_BIGENDIAN
+#if defined(TARGET_BIG_ENDIAN) == defined(WORDS_BIGENDIAN)
   return *(uint16_t *) (dat + addr);
 #else
   return *(uint16_t *) (dat + (addr ^ 2));
@@ -87,7 +87,7 @@ simmem_read16 (oraddr_t addr, void *dat)
 static uint8_t
 simmem_read8 (oraddr_t addr, void *dat)
 {
-#ifdef WORDS_BIGENDIAN
+#if defined(TARGET_BIG_ENDIAN) == defined(WORDS_BIGENDIAN)
   return *(uint8_t *) (dat + addr);
 #else
   return *(uint8_t *) (dat + (addr ^ 3));
@@ -103,7 +103,7 @@ simmem_write32 (oraddr_t addr, uint32_t value, void *dat)
 static void
 simmem_write16 (oraddr_t addr, uint16_t value, void *dat)
 {
-#ifdef WORDS_BIGENDIAN
+#if defined(TARGET_BIG_ENDIAN) == defined(WORDS_BIGENDIAN)
   *(uint16_t *) (dat + addr) = value;
 #else
   *(uint16_t *) (dat + (addr ^ 2)) = value;
@@ -113,7 +113,7 @@ simmem_write16 (oraddr_t addr, uint16_t value, void *dat)
 static void
 simmem_write8 (oraddr_t addr, uint8_t value, void *dat)
 {
-#ifdef WORDS_BIGENDIAN
+#if defined(TARGET_BIG_ENDIAN) == defined(WORDS_BIGENDIAN)
   *(uint8_t *) (dat + addr) = value;
 #else
   *(uint8_t *) (dat + (addr ^ 3)) = value;


### PR DESCRIPTION
In addition to running code on the [AR100](https://linux-sunxi.org/AR100) in little-endian mode, this is how I tested my little-endian toolchain patches. I'm not sure if this is worth merging in its current state, but at least it documents what parts of the code would need to be changed.

---

Only a few changes are needed to swap the target instruction endianness.
Most of these places are already conditional on the host endianness, but
the changes are not completely overlapping. Add a macro for the target
endianness so it can be swapped out.

In the future, this choice could come from the config file, but that
requires more refactoring.

Signed-off-by: Samuel Holland <samuel@sholland.org>