### PR TITLE
debug: Fix declaration/definition mismatch in `{set, get}_devint_reg`

### DIFF
--- a/debug/debug-unit.c
+++ b/debug/debug-unit.c
@@ -86,9 +86,9 @@ static int in_reset = 0;
 /*! Forward declaration of static functions */
 static int calculate_watchpoints (enum debug_unit_action action,
 				  unsigned long          udata);
-static int get_devint_reg (unsigned int   addr,
+static int get_devint_reg (enum development_interface_address_space addr,
 			   unsigned long *data);
-static int set_devint_reg (unsigned int   addr,
+static int set_devint_reg (enum development_interface_address_space addr,
 			   unsigned long  data);
 static int debug_set_mem (oraddr_t address, uorreg_t data);
 static int debug_get_mem (oraddr_t address, uorreg_t * data);


### PR DESCRIPTION
The declaration for `{set, get}_devint_reg` did not match the definition
later down the file, despite the enumeration being used as the argument of
the first type already being in scope. This caused warnings and an error
on certain compilers.
