### PR TITLE
fix: avoid the gcc stringop-overflow to build failed

### DIFF
--- a/argtable2/argtable2.c
+++ b/argtable2/argtable2.c
@@ -587,7 +587,8 @@ void arg_cat(char **pdest, const char *src, size_t *pndest)
         *dest++ = *src++;
 
     /* null terminate dest string */
-    *dest=0;
+    if (dest<=end)
+        *dest=0;
 
     /* update *pdest and *pndest */
     *pndest = end - dest;


### PR DESCRIPTION
OS：Ubuntu24.10 server
GCC: gcc (Ubuntu 14.2.0-4ubuntu2) 14.2.0

A new compilation option '-Werror=stringop-overflow' is supported after 2018 (i.e. after gcc8) for detecting buffer overflows. Compiling with a higher version of gcc can cause the following problems:

``` bash
In function 'arg_cat',
    inlined from 'arg_cat_option' at ../../argtable2/argtable2.c:655:13,
    inlined from 'arg_print_syntax' at ../../argtable2/argtable2.c:829:9:
../../argtable2/argtable2.c:591:10: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  591 |     *dest=0;
      |     ~~~~~^~
../../argtable2/argtable2.c: In function 'arg_print_syntax':
../../argtable2/argtable2.c:819:14: note: at offset 200 into destination object 'syntax' of size 200
  819 |         char syntax[200]="";
      |              ^~~~~~
In function 'arg_cat',
    inlined from 'arg_cat_option' at ../../argtable2/argtable2.c:654:13,
    inlined from 'arg_print_syntax' at ../../argtable2/argtable2.c:829:9:
../../argtable2/argtable2.c:591:10: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  591 |     *dest=0;
      |     ~~~~~^~
```

This is because a pointer here is not checked and the compile option has' -Wall-Werror 'turned on, so a pointer that is not checked is considered risky, and **we only need to perform a simple check (although it does not need to be checked)** :

``` bash
diff --git a/argtable2/argtable2.c b/argtable2/argtable2.c
index e40ec92..e744640 100644
--- a/argtable2/argtable2.c
+++ b/argtable2/argtable2.c
@@ -587,7 +587,8 @@ void arg_cat(char **pdest, const char *src, size_t *pndest)
         *dest++ = *src++;

     /* null terminate dest string */
-    *dest=0;
+    if (dest<=end)
+        *dest=0;

     /* update *pdest and *pndest */
     *pndest = end - dest;
```

Then, It works well.